### PR TITLE
Py refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Small installer for Java and/or Python
 
 define mvnpath
-	$(1) := $(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${settings.localRepository}" --non-recursive exec:exec)
+	$(1) := $(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${settings.localRepository}" --non-recursive exec:exec 2> /dev/null)
 endef
 
 define jarpath
 	$(eval $(call mvnpath, mvn_path))
-	groupId=$(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${project.groupId}" --non-recursive exec:exec | tr '.' '/')
-	artifactId=$(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${project.artifactId}" --non-recursive exec:exec)
-	version=$(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${project.version}" --non-recursive exec:exec)
+	groupId=$(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${project.groupId}" --non-recursive exec:exec 2> /dev/null | tr '.' '/')
+	artifactId=$(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${project.artifactId}" --non-recursive exec:exec 2> /dev/null)
+	version=$(shell mvn -q -Dexec.executable=echo -Dexec.args="\$${project.version}" --non-recursive exec:exec 2> /dev/null)
 	descriptorRef="jar-with-dependencies"
 	$(1) := "$(mvn_path)/$$(groupId)/$$(artifactId)/$$(version)/$$(artifactId)-$$(version)-$$(descriptorRef).jar"
 endef

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,14 @@ python: java
 java:
 	mvn install
 
+test: test-java test-python
+
+test-java:
+	mvn test
+
+test-python:
+	cd ./src/main/python && pytest
+
 mvn-path:
 	$(eval $(call mvnpath, mvn_path))
 	@echo ${mvn_path}

--- a/README.md
+++ b/README.md
@@ -132,20 +132,13 @@ Additional information can be found in the MATLAB and Octave Manuals
 
 ### Python
 
-After installing the Java package navigate to the python module
-`./src/main/python/` and install it with `pip`.
+The `nutmeg_reader` module depends on the java package and looks for it in the
+default maven install directory given by the command above or `make jar-path`.
+If the jar is in some other location, make sure `CLASSPATH` points to it before
+importing the python module.
 
 ```
-$ pip install . --use-feature=in-tree-build 
-```
-
-When creating a `NutmegReader` object a custom `class_path` can be specified,
-otherwise the default maven home `$HOME/.m2/repository` or the variable
-`MAVEN_HOME` will be used.
-
-```python
-nutreader = NutmegReader()
-nutreader = NutmegReader(class_path="some/other/path/to/nutmeg.jar")
+from nutmeg_reader import NutmegReader, read_nutmeg
 ```
 
 ## API
@@ -169,10 +162,15 @@ to get information how to call the functions in MATLAB / Octave.
 ### Python
 
 After importing the module, help for the classes can be found via the
-docstrings. For example, to get help on `NutmegReader` see:
+docstrings. For example, to get help for the `NutReader` class or the
+`read_nutmeg` function see:
 
 ```python
->>> help(NutmegReader)
+>>> from nutmeg_reader import NutReader, read_nutmeg
+
+>>> help(NutReader)
+
+>>> help(read_nutmeg)
 ```
 
 ## Example
@@ -260,25 +258,27 @@ title(plots(4).name);
 
 ### Python
 
+See the [readme](src/main/python/README.md) in the python module for further examples.
+
 ```python
-from nutmeg_reader import NutmegReader
-import pandas as pd
-from matplotlib import pyplot as plt
+nut_file    = '../../../test/resources/rc2/nutascii.raw'
+nut_reader  = NutReader.getNutasciiReader(nut_file)
 
-nutreader = NutmegReader()
+reader.read().parse();
 
-file = './src/test/resources/rc2/nutascii.raw'
-plots = nutreader.read_nutascii(file)
+plots       = reader.getPlots().toArray()
+tran_plot   = plots[3]
 
-tran_plot = plots[3]
-tran_data = pd.DataFrame(tran_plot.wave_data)
+tran_data   = pd.DataFrame({ w: tran_plot.getWave(w) 
+                             for w in tran_plot.getWaves().toArray() })
 
 fig, axs = plt.subplots(1,1, figsize=(8,8))
 axs.plot(tran_data['time'], tran_data['O'])
-axs.set_title(tran_plot.name)
-axs.set_xlabel(f'time ({tran_plot.wave_units["time"]})')
-axs.set_ylabel(f'O ({tran_plot.wave_units["O"]})')
+axs.set_title(tran_plot.getPlotname())
+axs.set_xlabel(f'time ({tran_plot.getUnit("time")})')
+axs.set_ylabel(f'O ({tran_plot.getUnit("O")})')
 plt.show()
+
 ```
 
 ![](fig/plot_python.png)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the dependency to your project
 <dependency>
   <groupId>edlab.eda</groupId>
   <artifactId>reader.nutmeg</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ title(plots(4).name);
 See the [readme](src/main/python/README.md) in the python module for further examples.
 
 ```python
+from nutmeg_reader import NutReader
+
 nut_file    = '../../../test/resources/rc2/nutascii.raw'
 nut_reader  = NutReader.getNutasciiReader(nut_file)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If the jar is in some other location, make sure `CLASSPATH` points to it before
 importing the python module.
 
 ```
-from nutmeg_reader import NutmegReader, read_nutmeg
+from nutmeg_reader import NutReader, read_nutmeg
 ```
 
 ## API

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edlab.eda</groupId>
 	<artifactId>reader.nutmeg</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/python/.gitignore
+++ b/src/main/python/.gitignore
@@ -2,11 +2,14 @@
 *.py[cod]
 *$py.class
 *.so
+*.log
 *.egg-info
 *.egg-info/
 *.egg
+
 .eggs/
 .Python
+.pytest_cache/
 __pycache__/
 build/
 develop-eggs/

--- a/src/main/python/README.md
+++ b/src/main/python/README.md
@@ -5,13 +5,97 @@ Python wrapper for the Java [nutmeg-reader](https://github.com/electronics-and-d
 ## Installation
 
 Since this package is built upon the java nutmeg-reader, it only works after
-the main package is installed.
+the main package is installed. Other dependencies are listed in
+`requrements.txt`.
 
 ```
 $ pip install . --use-feature=in-tree-build 
 ```
 
 ## Usage
+
+### CLI
+
+The nutmeg-reader python module comes with 2 CLI applications.
+
+1. `nut2hdf`: Convert nutmeg to [HDF5](https://hdfgroup.org/)
+2. `nut2csv`: Convert nutmeg to [CSV](https://en.wikipedia.org/wiki/Comma-separated_values)
+
+Other file formats may be supported in the future.
+
+For usage see the individual help
+
+```bash
+$ nut2hdf -h
+$ nut2csv --help
+```
+
+#### Example
+
+Converting a nutmeg file to a **single** HDF5 with the `-s` flag:
+
+```bash
+$ nut2hdf -s ../../test/resources/rc2/nutbin.raw
+
+$ h5ls -r ../../test/resources/rc2/nutbin.hdf
+/                        Group
+/ac                      Group
+/ac/I                    Dataset {51}
+/ac/O                    Dataset {51}
+/ac/R1:1                 Dataset {51}
+/ac/V0:p                 Dataset {51}
+/ac/freq                 Dataset {51}
+/dc1                     Group
+/dc1/I                   Dataset {1}
+/dc1/O                   Dataset {1}
+/dc1/R1:1                Dataset {1}
+/dc1/R1:pwr              Dataset {1}
+/dc1/V0:p                Dataset {1}
+/dc1/dummy               Dataset {1}
+/dc2                     Group
+/dc2/I                   Dataset {51}
+/dc2/O                   Dataset {51}
+/dc2/R1:1                Dataset {51}
+/dc2/R1:pwr              Dataset {51}
+/dc2/V0:p                Dataset {51}
+/dc2/VI                  Dataset {51}
+/tran                    Group
+/tran/I                  Dataset {56}
+/tran/O                  Dataset {56}
+/tran/R1:1               Dataset {56}
+/tran/R1:pwr             Dataset {56}
+/tran/V0:p               Dataset {56}
+/tran/time               Dataset {56}
+```
+
+Or to multiple files, on for each plot:
+
+```bash
+$ nut2hdf -s ../../test/resources/rc2/nutbin.raw
+
+$ tree ../../test/resources/rc2/
+../../test/resources/rc2/
+├── ...
+├── nutbin_ac.hdf
+├── nutbin_dc1.hdf
+├── nutbin_dc2.hdf
+├── nutbin.raw
+└── nutbin_tran.hdf
+
+$ h5ls -r ../../test/resources/rc2/nutbin_tran.hdf
+/                        Group
+/I                       Dataset {56}
+/O                       Dataset {56}
+/R1:1                    Dataset {56}
+/R1:pwr                  Dataset {56}
+/V0:p                    Dataset {56}
+/time                    Dataset {56}
+```
+
+Similarly, `nut2csv` produces CSV files, however it is impossible to store all
+plots in a single file.
+
+### API
 
 Before importing, make sure the java packe is installed. If the jar with all
 dependencies is not installed by maven, make sure the `CLASSPATH` environment
@@ -72,6 +156,16 @@ else:
 ```
 
 #### The simple way
+
+Import the convenience function
+
+```python
+from nutmeg_reader import read_nutmeg
+```
+
+which can read both ascii and binary Nutmeg files. The downside being, that it
+ignores meta information like the plot name, the unit etc. But it's simpler and
+returns a [pandas DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html).
 
 ```python
 # Get a dictionary of all plots

--- a/src/main/python/README.md
+++ b/src/main/python/README.md
@@ -13,26 +13,93 @@ $ pip install . --use-feature=in-tree-build
 
 ## Usage
 
+Before importing, make sure the java packe is installed. If the jar with all
+dependencies is not installed by maven, make sure the `CLASSPATH` environment
+variable is set and points to the jar.
+
+```bash
+$ export CLASSPATH=/path/to/jar-with-dependencies.jar
+```
+
+Otherwise `nutmeg_reader` will look for it in the default maven install.
+
+#### The Java way
+
 Import the main class
 
 ```python
-from nutmeg_reader import NutmegReader
+from nutmeg_reader import NutReader
 ```
 
-then create a new object.
+from here on it can be used _exactly_ the same as the java class.
 
 ```python
-nutreader = NutmegReader()
-nutreader = NutmegReader(class_path="some/other/path/to/nutmeg.jar")
+# Create a new reader
+reader = NutReader.getNutasciiReader('../../test/resources/rc2/nutascii.raw')
+
+# Read and parse the nutascii
+reader.read().parse();
+
+# Get all plots from the reader
+plots = reader.getPlots().toArray()
+
+# Get nutmeg plot from list
+plot = plots.get(0)
+
+# Get the name of a plot
+plot.getPlotname()
+
+# Get number of points from plot
+plot.getNoOfPoints()
+
+# Get number of variables from plot
+plot.getNoOfVariables()
+
+# Get set of all waves from plot
+waves = plot.getWaves().toArray()
+
+# Check if wave with name 'I' is part of plot
+plot.containsWave('I')
+
+# Get unit of wave with name 'I'
+plot.getUnit('I')
+
+# Get the waveform (be careful about complex values!)
+if plot.isComplex():
+    wave = [complex(p.getReal(), p.getImaginary()) for p in plot.getWave('I')]
+else:
+    wave = plot.getWave('I')
 ```
 
-optionally one can pass a custom `class_path`, otherwise the `MAVEN_HOME`
-environment variable will be used or the default maven path at
-`$HOME/.m2/repository`.
+#### The simple way
+
+```python
+# Get a dictionary of all plots
+plots = read_nutmeg('../../../test/resources/rc2/nutbin.raw')
+
+# Picking a plot returns a pandas DataFrame
+plot = bin_plots['tran']
+
+# Get number of points from plot
+len(plot.index)
+
+# Get number of variables from plot
+len(plot.columns)
+
+# Get set of all waves
+plot.columns
+
+# Check if wave with name 'I' is part of plot
+'I' in plot.columns
+
+# Get the waveform 
+wave = plot['I'].values
+```
 
 ## Tests
 
+Run this in the root of the python packge:
+
 ```
-$ cd tests
 $ pytest
 ```

--- a/src/main/python/nutmeg_reader/__init__.py
+++ b/src/main/python/nutmeg_reader/__init__.py
@@ -1,1 +1,1 @@
-from .nutmeg_reader import NutmegReader, NutmegPlot, __version__
+from .nutmeg_reader import Nutreader, read_nutmeg, nut2csv, nut2hdf

--- a/src/main/python/nutmeg_reader/__init__.py
+++ b/src/main/python/nutmeg_reader/__init__.py
@@ -1,1 +1,24 @@
-from .nutmeg_reader import Nutreader, read_nutmeg, nut2csv, nut2hdf
+import os
+from pkg_resources import get_distribution
+
+__name__    = 'nutmeg_reader'
+__version__ = get_distribution(__name__).version
+
+def __get_maven_home():
+    mvn_command  = 'mvn help:evaluate -Dexpression=settings.localRepository -B 2> /dev/null'
+    maven_output = os.popen(mvn_command).read()
+    maven_home   = list(filter( lambda l: (not l.startswith('[')) and l
+                              , maven_output.split(sep='\n')))[0]
+    return maven_home
+
+def __default_class_path():
+    maven_home = __get_maven_home()
+    class_path = f'{maven_home}/edlab/eda/reader.nutmeg/{__version__}/reader.nutmeg-{__version__}-jar-with-dependencies.jar'
+    return class_path
+
+if 'CLASSPATH' not in os.environ.keys():
+    cp = __default_class_path()
+    import jnius_config
+    jnius_config.set_classpath(cp)
+
+from .nutmeg_reader import NutReader, read_nutmeg

--- a/src/main/python/nutmeg_reader/__main__.py
+++ b/src/main/python/nutmeg_reader/__main__.py
@@ -1,3 +1,45 @@
+import os
+import argparse
+from pkg_resources import get_distribution
+from .nutmeg_reader import NutReader, read_nutmeg 
+
+__name__    = 'nutmeg_reader'
+__version__ = get_distribution(__name__).version
+
+def __convert_nutmeg(file_type: str) -> int:
+    parser = argparse.ArgumentParser(description=f'Convert Nutmeg to {file_type}.')
+
+    parser.add_argument( '--version', action="version"
+                       , version=f'{__name__}: {__version__}'
+                       , )
+
+    parser.add_argument( 'file', type=str, nargs=1
+                       , help='Path to Nutmeg input file'
+                       , )
+
+    parser.add_argument( '-o', '--override', action='store_true'
+                       , help='Override target files if they exist.')
+
+    if file_type == 'HDF':
+        parser.add_argument( '-s', '--single', action='store_true'
+                           , help='Put all plots into a single HDF file')
+
+    return 0
+
+def nut2hdf() -> int:
+    '''
+    nut2hdf: Entry point for converting Nutmeg to HDF5.
+        Returns exit code.
+    '''
+    return __convert_nutmeg('HDF')
+
+def nut2csv() -> int:
+    '''
+    nut2csv: Entry point for converting Nutmeg to CSV.
+        Returns exit code.
+    '''
+    return __convert_nutmeg('CSV')
+
 def main():
     return 0
 

--- a/src/main/python/nutmeg_reader/__main__.py
+++ b/src/main/python/nutmeg_reader/__main__.py
@@ -34,14 +34,14 @@ def __convert_nutmeg(file_type: str) -> int:
 
     return 0
 
-def nut2hdf() -> int:
+def n2h() -> int:
     '''
     nut2hdf: Entry point for converting Nutmeg to HDF5.
         Returns exit code.
     '''
     return __convert_nutmeg('HDF')
 
-def nut2csv() -> int:
+def n2c() -> int:
     '''
     nut2csv: Entry point for converting Nutmeg to CSV.
         Returns exit code.

--- a/src/main/python/nutmeg_reader/__main__.py
+++ b/src/main/python/nutmeg_reader/__main__.py
@@ -1,7 +1,7 @@
 import os
 import argparse
 from pkg_resources import get_distribution
-from .nutmeg_reader import NutReader, read_nutmeg 
+from .nutmeg_reader import nut2hdf, nut2csv
 
 __name__    = 'nutmeg_reader'
 __version__ = get_distribution(__name__).version
@@ -13,7 +13,7 @@ def __convert_nutmeg(file_type: str) -> int:
                        , version=f'{__name__}: {__version__}'
                        , )
 
-    parser.add_argument( 'file', type=str, nargs=1
+    parser.add_argument( 'files', type=str, nargs='+'
                        , help='Path to Nutmeg input file'
                        , )
 
@@ -23,6 +23,14 @@ def __convert_nutmeg(file_type: str) -> int:
     if file_type == 'HDF':
         parser.add_argument( '-s', '--single', action='store_true'
                            , help='Put all plots into a single HDF file')
+
+    args = parser.parse_args()
+
+    for file_name in args.files:
+        if file_type == 'HDF':
+            nut2hdf(file_name, args.single, args.override)
+        elif file_type == 'CSV':
+            nut2csv(file_name, args.override)
 
     return 0
 

--- a/src/main/python/nutmeg_reader/nutmeg_reader.py
+++ b/src/main/python/nutmeg_reader/nutmeg_reader.py
@@ -1,170 +1,125 @@
 import os
+import re
 import errno
+import magic
 import warnings
 
-import jpype
-import jpype.imports
-from jpype.types import *
+from typing import Union
 
-import numpy as np
+import h5py as h5
 import pandas as pd
+
+from jnius import autoclass
 
 __version__ = '1.0.1'
 
-def __get_maven_home():
-    mvn_command  = 'mvn help:evaluate -Dexpression=settings.localRepository -B'
-    maven_output = os.popen(mvn_command).read()
-    maven_home   = list(filter( lambda l: (not l.startswith('[')) and l
-                              , maven_output.split(sep='\n')))[0]
-    return maven_home
+def _analysis_type(plot_name: str) -> str:
+    analysis_pattern = "`(.*?)'"
+    return re.search(analysis_pattern, plot_name).group(1)
 
-def __default_class_path():
-    maven_home = __get_maven_home()
-    class_path = f'{maven_home}/edlab/eda/reader/nutmeg/{__version__}/nutmeg-{__version__}-jar-with-dependencies.jar'
-    return class_path
+def _file_names( file_name: str , plots: list[str]
+               , extension: str ) -> list[str]:
+    fb = f'{os.path.splitext(os.path.abspath(file_name))[0]}'
+    return [ f'{fb}_{_analysis_type(p)}.{extension}' for p in plots ]
 
-DEFAULT_CLASS_PATH = __default_class_path()
+def _data_frame(plot: Union[ jnius.reflect.edlab.eda.reader.nutmeg.NutmegPlot
+                           , jnius.reflect.edlab.eda.reader.nutmeg.NutmegComplexPlot ]
+               ) -> pd.DataFrame:
+    c = lambda p: complex(p.getReal(), p.getImaginary())
+    d = { w: plot.getWave(w) if not plot.complex else [c(p) for p in wave]
+          for w in plot.getWaves().toArray() }
+    return pd.DataFrame(d)
 
-class NutmegPlot:
+NutReader = autoclass('edlab.eda.reader.nutmeg.NutReader')
+
+def read_nutmeg(file_name: str) -> dict[str, pd.DataFrame]:
     '''
-    Every plot has properties:
-        name = plot1.name                   references the name of the plot
-        numOfWaves = plot1.num_of_waves     references the number of waves
-        numOfPoints = plot1.num_of_points    references the number of points
-
-    The name of a waveform can be accessed with:
-        name_1 = plot1.wave_names[0]    retrives the name of the first waveform
-        name_2 = plot1.wave_names[1]    retrives the name of the second waveform
-
-    The unit of a waveform can be accessed with:
-        unit_1 = plot1.wave_units[name_1]   retrives the unit of the first
-                                            waveform 
-        unit_2 = plot1.wave_units[name_2]   retrives the unit of the second 
-                                            waveform
-
-    The wave of a waveform can be accessed with:
-        wave_1 = plot1.wave_data[name_1].values  retrives the wave of the first
-                                                 waveform as numpy array
-        wave_2 = plot1.wave_data[name_2].values  retrives the wave of the second 
-                                                 waveform as numpy array
-     
-        The entry plot1.wave_data is a dictionary with a numpy array for each
-        wave name.
+    read_nutmeg: 
+        Reads the contents of a Nutmeg file in binary or ascii format and
+        returns a dictionary with all the plots contained within as pandas
+        DataFrames.
+        Arguments:
+            file_name: Path to nutmeg file.
+        Returns:
+            Dictionary with plot names as keys and pandas DataFrames as values
+            for each plot.
     '''
-    def __init__(self, plot):
-        '''
-        Constructor for the NutmegPlot class. Takes a NutmegReader Plot object
-        and converts it to something useful in python.
-        '''
-        self.plot          = plot
-        self.is_complex    = plot.isComplex()
-        self.name          = plot.getPlotname()
-        self.num_of_waves  = plot.getNoOfWaves()
-        self.num_of_points = plot.getNoOfPoints()
+    if not (os.path.isfile(file_name) and os.access(file_name, os.R_OK)):
+        raise FileNotFoundError( errno.ENOENT
+                               , os.strerror(errno.ENOENT)
+                               , file_name )
 
-        self.wave_names = [ str(wav.toString())
-                            for wav in plot.getWaves().toArray() ]
-        self.wave_units = { wn: self.plot.getUnit(wn)
-                            for wn in self.wave_names }
+    nutmeg_format = magic.from_file(file_name)
 
-        self.wave_data  = { wn: np.array([ w.getReal() + 1j * w.getImaginary() 
-                                          for w in wf ]) \
-                                if self.is_complex else np.array(wf)
-                            for wn, wf in [ (w, plot.getWave(w)) 
-                                            for w in self.wave_names ] }
+    if nutmeg_format == 'data':
+        reader = NutReader.getNutbinReader(file_name) 
+    elif nutmeg_format == 'ASCII text':
+        reader = NutReader.getNutasciiReader(file_name)
+    else:
+        raise IOError( errno.EBFONT
+                     , os.strerror(errno.EBFONT)
+                     , file_name )
+             
+    reader.read().parse()
 
-class NutmegReader:
-    _nut_reader = None
-    _class_path = None
+    return { _analysis_type(plot.getPlotname()): _data_frame(plot)
+             for plot in reader.getPlots().toArray() }
 
-    def __init__(self, class_path=DEFAULT_CLASS_PATH):
-        '''
-        Constructor of the NutmegReader class. Takes an optional class path and
-        starts the jvm.
-        Where `class_path` should point to the nutmeg-reader `.jar`. If the
-        nutmeg-reader was installed following the instructions this should be
-        unecessary.
-        
-        **NOTE:** If a jpype has already a JVM running, the class_path arg will
-        be ignored until all objects are `del`ed and the JVM is killed.
-        '''
-        ## Check if given nutmeg jar exists
-        if not os.path.isfile(class_path):
-            raise FileNotFoundError( errno.ENOENT
-                                   , os.strerror(errno.ENOENT)
-                                   , class_path )
+def nut2hdf( file_name: str, single: bool = False
+           , override: bool = False ) -> Union[str, list[str]]:
+    '''
+    nut2hdf: 
+        Takes path to nutmeg file, reads it and writes the contents to either a
+        single HDF5 with groups per plot, or individual HDF5s per plot.
+        Arguments:
+            file_name: Path to nutmeg format raw file.
+            [override]: Override if file already exists. (default = False).
+            [verbose]: Optional verbose output. (default = False )
+        Returns:
+            Path(s) to HDF5 file(s).
+    '''
+    nutmeg_data = read_nutmeg(file_name)
 
-        ## Set class path or warn about running JVM
-        if NutmegReader._class_path is None:
-            NutmegReader._class_path = class_path
-        elif jpype.isJVMStarted() and (NutmegReader._class_path != class_path):
-            w1 = f'JVM is already running with a different class path {NutmegReader._class_path}.\n'
-            w2 = f'Close the current JVM to start with a different class path.\n'
-            warnings.warn( f'\n{w1}\n{w2}\n'
-                         , RuntimeWarning ) 
+    if single:
+        hdf_files = [f'{os.path.splitext(os.path.abspath(file_name))[0]}.hdf']
+    else:
+        hdf_files = _file_names(file_name, list(nutmeg_data.keys()), 'hdf') 
 
-        ## Start JVM if not running and set static variable
-        if not jpype.isJVMStarted():
-            jpype.startJVM(classpath=[NutmegReader._class_path])
-            from edlab.eda.reader.nutmeg import NutReader
-            NutmegReader._nut_reader = NutReader
+    if any([os.path.isfile(f) for f in hdf_files]) and not override:
+        raise IOError(errno.EEXIST, os.strerror(errno.EEXIST), hdf_files)
+    
+    if single:
+        with h5.File(hdf_files[0], 'w') as hdf_file:
+            for plot, data in nutmeg_data.items():
+                group = hdf_file.create_group(plot)
+                for col in data:
+                    group[col] = data[col].to_numpy()
+    else:
+        for file, data in zip(hdf_files, nutmeg_data.values()):
+            with h5.File(file, 'w') as hdf_file:
+                for col in data:
+                    hdf_file[col] = data[col].to_numpy()
 
-    def __del__(self):
-        '''
-        Destructor will shutdown the JVM and set `_nut_reader = None`.
-        '''
-        NutmegReader._nut_reader = None
-        if jpype.isJVMStarted():
-            jpype.shutdownJVM()
+    return hdf_files[0] if single else hdf_files
 
-    def __read_nutmeg(self, file_name, nut_type):
-        '''
-        Private reader function for handling ascii and bin types.
-        See documentation for `readNutascii` and/or `readNutbin`.
-        '''
-        if os.path.isfile(file_name):   # Check if file exists
-            if nut_type == 'ascii':
-                reader = NutmegReader._nut_reader.getNutasciiReader(file_name)
-            else:                       # Raise error of file doesn't exist
-                reader = NutmegReader._nut_reader.getNutbinReader(file_name)
+def nut2csv(file_name: str, override: bool = False) -> str:
+    '''
+    nut2csv: 
+        Takes path to nutmeg file, reads it and writes the contents to CSV
+        files, for each plot.
+        Arguments:
+            file_name: Path to nutmeg format raw file.
+            [verbose]: Optional verbose output.
+        Returns:
+            Paths to CSV files.
+    '''
+    nutmeg_data = read_nutmeg(file_name)
+    csv_files = _file_names(file_name, list(nutmeg_data.keys()), 'csv')
+    
+    if any([os.path.isfile(f) for f in csv_files]) and not override:
+        raise IOError(errno.EEXIST, os.strerror(errno.EEXIST), csv_files)
 
-            # Read and parse the file
-            reader.read()
-            reader.parse()
-
-            # Extract the plots as array
-            plots = [NutmegPlot(plot) for plot in reader.getPlots().toArray()]
-        else:
-            raise FileNotFoundError( errno.ENOENT
-                                   , os.strerror(errno.ENOENT)
-                                   , file_name)
-        return plots
-
-    def read_nutascii(self, file_name: str):
-        ''' 
-        read_nutascii : Reads the contents of a Nutmeg file in ascii syntax.
-
-            `plots = read_nutascii(file_name)` reads the contents of 'file_name'.
-         
-        The function returns an array with the individual plots in the file as
-        `NutmegPlot` objects.
-         
-        plot1 = plots[0] accesses the first plot in the file
-        plot2 = plots[1] accesses the second plot in the file
-        ...
-        '''
-        return self.__read_nutmeg(file_name, 'ascii')
-
-    def read_nutbin(self, file_name: str):
-        ''' 
-        read_nutabin : Reads the contents of a Nutmeg file in binary syntax.
-
-            `plots = read_nutbin(file_name)` reads the contents of 'file_name'.
-         
-        The function returns an array with the individual plots in the file.
-         
-        plot1 = plots[0] accesses the first plot in the file
-        plot2 = plots[1] accesses the second plot in the file
-        ...
-        '''
-        return self.__read_nutmeg(file_name, 'bin')
+    for file, data in zip(csv_files, nutmeg_data.values()):
+        data.to_csv(file)
+    
+    return csv_files

--- a/src/main/python/nutmeg_reader/nutmeg_reader.py
+++ b/src/main/python/nutmeg_reader/nutmeg_reader.py
@@ -11,7 +11,9 @@ import pandas as pd
 
 from jnius import autoclass
 
-__version__ = '1.0.1'
+NutmegRealPlot      = autoclass('edlab.eda.reader.nutmeg.NutmegRealPlot')
+NutmegComplexPlot   = autoclass('edlab.eda.reader.nutmeg.NutmegComplexPlot')
+NutReader           = autoclass('edlab.eda.reader.nutmeg.NutReader')
 
 def _analysis_type(plot_name: str) -> str:
     analysis_pattern = "`(.*?)'"
@@ -22,15 +24,11 @@ def _file_names( file_name: str , plots: list[str]
     fb = f'{os.path.splitext(os.path.abspath(file_name))[0]}'
     return [ f'{fb}_{_analysis_type(p)}.{extension}' for p in plots ]
 
-def _data_frame(plot: Union[ jnius.reflect.edlab.eda.reader.nutmeg.NutmegPlot
-                           , jnius.reflect.edlab.eda.reader.nutmeg.NutmegComplexPlot ]
-               ) -> pd.DataFrame:
+def _data_frame(plot: Union[NutmegRealPlot, NutmegComplexPlot]) -> pd.DataFrame:
     c = lambda p: complex(p.getReal(), p.getImaginary())
     d = { w: plot.getWave(w) if not plot.complex else [c(p) for p in wave]
           for w in plot.getWaves().toArray() }
     return pd.DataFrame(d)
-
-NutReader = autoclass('edlab.eda.reader.nutmeg.NutReader')
 
 def read_nutmeg(file_name: str) -> dict[str, pd.DataFrame]:
     '''

--- a/src/main/python/nutmeg_reader/nutmeg_reader.py
+++ b/src/main/python/nutmeg_reader/nutmeg_reader.py
@@ -22,11 +22,11 @@ def _analysis_type(plot_name: str) -> str:
 def _file_names( file_name: str , plots: list[str]
                , extension: str ) -> list[str]:
     fb = f'{os.path.splitext(os.path.abspath(file_name))[0]}'
-    return [ f'{fb}_{_analysis_type(p)}.{extension}' for p in plots ]
+    return [ f'{fb}_{p}.{extension}' for p in plots ]
 
 def _data_frame(plot: Union[NutmegRealPlot, NutmegComplexPlot]) -> pd.DataFrame:
     c = lambda p: complex(p.getReal(), p.getImaginary())
-    d = { w: plot.getWave(w) if not plot.complex else [c(p) for p in wave]
+    d = { w: plot.getWave(w) if not plot.complex else [c(p) for p in plot.getWave(w)]
           for w in plot.getWaves().toArray() }
     return pd.DataFrame(d)
 

--- a/src/main/python/requirements.txt
+++ b/src/main/python/requirements.txt
@@ -1,3 +1,5 @@
-JPype1
+pyjnius
+python-magic
 numpy
+pandas
 matplotlib

--- a/src/main/python/requirements.txt
+++ b/src/main/python/requirements.txt
@@ -1,5 +1,4 @@
 pyjnius
 python-magic
-numpy
 pandas
-matplotlib
+h5py

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -22,6 +22,6 @@ setuptools.setup( name                          = package_name
                                                   , 'Operating System :: POSIX :: Linux' ]
                 , python_requires               = '>=3.8'
                 , install_requires              = requirements
-                , entry_points                  = { 'console_scripts': [ 'nut2hdf = nutmeg_reader.__main__:nut2hdf' 
-                                                                       , 'nut2csv = nutmeg_reader.__main__:nut2csv' ]}
+                , entry_points                  = { 'console_scripts': [ 'nut2hdf = nutmeg_reader.__main__:n2h' 
+                                                                       , 'nut2csv = nutmeg_reader.__main__:n2c' ]}
                 , )

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -1,6 +1,6 @@
 import setuptools
  
-package_name = 'nutmegreader'
+package_name = 'nutmeg_reader'
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
@@ -22,6 +22,6 @@ setuptools.setup( name                          = package_name
                                                   , 'Operating System :: POSIX :: Linux' ]
                 , python_requires               = '>=3.8'
                 , install_requires              = requirements
-                #, entry_points                  = { 'console_scripts': [ 'FIXME' ]}
-                #, package_data                  = { '': ['*.hy', '__pycache__/*']}
+                , entry_points                  = { 'console_scripts': [ 'nut2hdf = nutmeg_reader.__main__:pct' 
+                                                                       , 'nut2csv = nutmeg_reader.__main__:prc' ]}
                 , )

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt', 'r') as req:
     requirements = req.read().splitlines()
  
 setuptools.setup( name                          = package_name
-                , version                       = '1.0.1'
+                , version                       = '1.0.2'
                 , author                        = 'Yannick Uhlmann, Matthias Schweikardt'
                 , author_email                  = 'yannick.uhlmann@reutlingen-university.de'
                 , description                   = 'Nutmeg reader for python based on Java implementation.'

--- a/src/main/python/setup.py
+++ b/src/main/python/setup.py
@@ -22,6 +22,6 @@ setuptools.setup( name                          = package_name
                                                   , 'Operating System :: POSIX :: Linux' ]
                 , python_requires               = '>=3.8'
                 , install_requires              = requirements
-                , entry_points                  = { 'console_scripts': [ 'nut2hdf = nutmeg_reader.__main__:pct' 
-                                                                       , 'nut2csv = nutmeg_reader.__main__:prc' ]}
+                , entry_points                  = { 'console_scripts': [ 'nut2hdf = nutmeg_reader.__main__:nut2hdf' 
+                                                                       , 'nut2csv = nutmeg_reader.__main__:nut2csv' ]}
                 , )

--- a/src/main/python/tests/demo_nutmeg.py
+++ b/src/main/python/tests/demo_nutmeg.py
@@ -1,18 +1,35 @@
-from nutmeg_reader import NutmegReader
 import pandas as pd
 from matplotlib import pyplot as plt
+from nutmeg_reader import NutReader, read_nutmeg
 
-nutreader = NutmegReader()
+## The slightly longer and painful way with all the information:
 
-bin_plots = nutreader.read_nutbin('../../../test/resources/rc2/nutbin.raw')
+nut_file    = '../../../test/resources/rc2/nutascii.raw'
+nut_reader  = NutReader.getNutasciiReader(nut_file)
 
-tran_plot = bin_plots[3]
+reader.read().parse();
 
-tran_data = pd.DataFrame(tran_plot.wave_data)
+plots       = reader.getPlots().toArray()
+tran_plot   = plots[3]
+
+tran_data   = pd.DataFrame({ w: tran_plot.getWave(w) 
+                             for w in tran_plot.getWaves().toArray() })
 
 fig, axs = plt.subplots(1,1, figsize=(8,8))
 axs.plot(tran_data['time'], tran_data['O'])
-axs.set_title(tran_plot.name)
-axs.set_xlabel(f'time ({tran_plot.wave_units["time"]})')
-axs.set_ylabel(f'O ({tran_plot.wave_units["O"]})')
+axs.set_title(tran_plot.getPlotname())
+axs.set_xlabel(f'time ({tran_plot.getUnit("time")})')
+axs.set_ylabel(f'O ({tran_plot.getUnit("O")})')
+plt.show()
+
+## Or with the `read_nutmeg` convenience function, but less information:
+
+bin_plots = read_nutmeg('../../../test/resources/rc2/nutbin.raw')
+tran_data = bin_plots['tran']
+
+fig, axs = plt.subplots(1,1, figsize=(8,8))
+axs.plot(tran_data['time'], tran_data['O'])
+axs.set_title('tran')
+axs.set_xlabel(f'time (s)')
+axs.set_ylabel(f'O (V)')
 plt.show()

--- a/src/main/python/tests/test_nutmeg.py
+++ b/src/main/python/tests/test_nutmeg.py
@@ -1,33 +1,37 @@
-from nutmeg_reader import NutmegReader
-
-nutreader = NutmegReader()
+from nutmeg_reader import NutReader
 
 def test_nutbin():
-    bin_plots = nutreader.read_nutbin('../../../test/resources/rc2/nutbin.raw')
+    bin_file    = '../../../test/resources/rc2/nutbin.raw'
+    bin_reader  = NutReader.getNutbinReader(bin_file)
+    bin_reader.read().parse();
+    bin_plots   = bin_reader.getPlots().toArray()
 
     assert(len(bin_plots) == 4)
 
-    assert(bin_plots[0].num_of_points == 1)
-    assert(bin_plots[1].num_of_points == 51)
-    assert(bin_plots[2].num_of_points == 51)
-    assert(bin_plots[3].num_of_points == 56)
+    assert(bin_plots[0].getNoOfPoints == 1)
+    assert(bin_plots[1].getNoOfPoints == 51)
+    assert(bin_plots[2].getNoOfPoints == 51)
+    assert(bin_plots[3].getNoOfPoints == 56)
 
-    assert(bin_plots[0].num_of_waves == 6)
-    assert(bin_plots[1].num_of_waves == 6)
-    assert(bin_plots[2].num_of_waves == 5)
-    assert(bin_plots[3].num_of_waves == 6)
+    assert(bin_plots[0].getNoOfWaves == 6)
+    assert(bin_plots[1].getNoOfWaves == 6)
+    assert(bin_plots[2].getNoOfWaves == 5)
+    assert(bin_plots[3].getNoOfWaves == 6)
 
 def test_ascii():
-    asc_plots = nutreader.read_nutascii('../../../test/resources/rc2/nutascii.raw')
+    asc_file    = '../../../test/resources/rc2/nutascii.raw'
+    asc_reader  = NutReader.getNutasciiReader(asc_file)
+    asc_reader.read().parse();
+    asc_plots   = asc_reader.getPlots().toArray()
 
     assert(len(asc_plots) == 4)
 
-    assert(asc_plots[0].num_of_points == 1)
-    assert(asc_plots[1].num_of_points == 51)
-    assert(asc_plots[2].num_of_points == 51)
-    assert(asc_plots[3].num_of_points == 56)
+    assert(asc_plots[0].getNoOfPoints == 1)
+    assert(asc_plots[1].getNoOfPoints == 51)
+    assert(asc_plots[2].getNoOfPoints == 51)
+    assert(asc_plots[3].getNoOfPoints == 56)
 
-    assert(asc_plots[0].num_of_waves == 6)
-    assert(asc_plots[1].num_of_waves == 6)
-    assert(asc_plots[2].num_of_waves == 5)
-    assert(asc_plots[3].num_of_waves == 6)
+    assert(asc_plots[0].getNoOfWaves == 6)
+    assert(asc_plots[1].getNoOfWaves == 6)
+    assert(asc_plots[2].getNoOfWaves == 5)
+    assert(asc_plots[3].getNoOfWaves == 6)

--- a/src/main/python/tests/test_nutmeg.py
+++ b/src/main/python/tests/test_nutmeg.py
@@ -1,37 +1,37 @@
 from nutmeg_reader import NutReader
 
 def test_nutbin():
-    bin_file    = '../../../test/resources/rc2/nutbin.raw'
+    bin_file    = '../../test/resources/rc2/nutbin.raw'
     bin_reader  = NutReader.getNutbinReader(bin_file)
     bin_reader.read().parse();
     bin_plots   = bin_reader.getPlots().toArray()
 
     assert(len(bin_plots) == 4)
 
-    assert(bin_plots[0].getNoOfPoints == 1)
-    assert(bin_plots[1].getNoOfPoints == 51)
-    assert(bin_plots[2].getNoOfPoints == 51)
-    assert(bin_plots[3].getNoOfPoints == 56)
+    assert(bin_plots[0].getNoOfPoints() == 1)
+    assert(bin_plots[1].getNoOfPoints() == 51)
+    assert(bin_plots[2].getNoOfPoints() == 51)
+    assert(bin_plots[3].getNoOfPoints() == 56)
 
-    assert(bin_plots[0].getNoOfWaves == 6)
-    assert(bin_plots[1].getNoOfWaves == 6)
-    assert(bin_plots[2].getNoOfWaves == 5)
-    assert(bin_plots[3].getNoOfWaves == 6)
+    assert(bin_plots[0].getNoOfWaves() == 6)
+    assert(bin_plots[1].getNoOfWaves() == 6)
+    assert(bin_plots[2].getNoOfWaves() == 5)
+    assert(bin_plots[3].getNoOfWaves() == 6)
 
 def test_ascii():
-    asc_file    = '../../../test/resources/rc2/nutascii.raw'
+    asc_file    = '../../test/resources/rc2/nutascii.raw'
     asc_reader  = NutReader.getNutasciiReader(asc_file)
     asc_reader.read().parse();
     asc_plots   = asc_reader.getPlots().toArray()
 
     assert(len(asc_plots) == 4)
 
-    assert(asc_plots[0].getNoOfPoints == 1)
-    assert(asc_plots[1].getNoOfPoints == 51)
-    assert(asc_plots[2].getNoOfPoints == 51)
-    assert(asc_plots[3].getNoOfPoints == 56)
+    assert(asc_plots[0].getNoOfPoints() == 1)
+    assert(asc_plots[1].getNoOfPoints() == 51)
+    assert(asc_plots[2].getNoOfPoints() == 51)
+    assert(asc_plots[3].getNoOfPoints() == 56)
 
-    assert(asc_plots[0].getNoOfWaves == 6)
-    assert(asc_plots[1].getNoOfWaves == 6)
-    assert(asc_plots[2].getNoOfWaves == 5)
-    assert(asc_plots[3].getNoOfWaves == 6)
+    assert(asc_plots[0].getNoOfWaves() == 6)
+    assert(asc_plots[1].getNoOfWaves() == 6)
+    assert(asc_plots[2].getNoOfWaves() == 5)
+    assert(asc_plots[3].getNoOfWaves() == 6)


### PR DESCRIPTION
## Python Refactor

Now using [jnius](https://pyjnius.readthedocs.io/en/stable/index.html) instead of ~~jpype~~. Complete re-write, without creating a separate python wrapper class, but instead using the java classes natively.

### CLI

Added command line tools for converting nutmeg files to HDF5 and CSV.

- `nut2hdf`: Convert nutmeg to HDF5
- `nut2csv`: Covnert nutmeg to set of CSV files

### Version

Version is now single sourced in `setup.py`.

## Makefile

Gobbeld warning for mvn commands in `Makefile`.